### PR TITLE
Restore Field service page rewrites lost in merge conflict

### DIFF
--- a/docs/user-guide/guide/field-service/departments-field-service.md
+++ b/docs/user-guide/guide/field-service/departments-field-service.md
@@ -1,25 +1,45 @@
 # Departments
 
-The **Departments** section in Navixy's **Field service** application allows you to organize your workforce effectively by categorizing employees into specific departments. This organizational structure helps streamline task assignments, reporting, and overall management of field operations.
+The **Departments** page in Navixy's **Field service** module allows you to organize your workforce by categorizing employees into specific departments. This organizational structure helps streamline task assignments, reporting, and overall management of field operations.
 
-![Creating new department (example)](../../.gitbook/assets/image-20240816-172857.png)
+You can assign employees to departments on the [Staff](staff.md#assign-employee-to-department) page.
 
-## Managing departments
+<figure><img src="../../.gitbook/assets/{7F96E3FF-ACF9-4C49-B1BA-34D5E4DB3C0A}.png" alt="Departments page"><figcaption><p>Departments page</p></figcaption></figure>
 
-In the Departments section, you can create, view, and manage different departments within your organization. Each department can be labeled appropriately, such as "Delivery department" or "Sales department," to reflect the specific function of the team.
+The department list is used to manage different departments in your organization. Each department can be labeled, such as "Delivery" or "Sales," to reflect the specific function of the team.
 
-#### Creating a new department
+## How to create a new department
 
-1. **Navigate to the Departments tab**: Start by going to the Departments section within the Field Service application.
-2. **Click the “+” button**: To create a new department, click the “+” button.
-3. **Enter department details**:
-   1. **Label**: Provide a name for the department, such as "Main office" or "Service Department."
-   2. **Address**: Enter the physical location of the department, or use the map to select a precise location.
-   3. **Radius**: Define a radius around the department’s location. This helps in assigning tasks based on proximity to the department.
-4. **Save**: After filling in the necessary details, click "Save" to create the department.
+{% stepper %}
+{% step %}
+### Go to Departments
 
-### Department details
+Open the **Departments** page in the **Field service** module.
+{% endstep %}
 
-Once a department is created, it will be listed in the Departments section, where you can view its details such as the label and address. This section also allows you to edit or delete departments as needed.
+{% step %}
+### Start creating a department
 
-By using the Departments section effectively, you can ensure that tasks are assigned to the appropriate teams, enhancing the efficiency and productivity of your field service operations.
+Click **+** to open the department creation dialogue.
+{% endstep %}
+
+{% step %}
+### Enter department details
+
+![Creating a new department](<../../.gitbook/assets/image-20240816-172857 (3).png>)
+
+* **Label**: Provide a name for the department.
+* **Address**: Enter the department's physical location or use the map to select a point.
+* **Radius**: Define a radius around the department’s location. This helps in assigning tasks based on proximity to the department.
+{% endstep %}
+
+{% step %}
+### Finish creating the department
+
+After filling in the necessary details, click **Save** to create the department.
+{% endstep %}
+{% endstepper %}
+
+Once a department is created, it will appear on the **Departments** page, where you can view its details, such as name and address. This page also allows you to edit or delete departments as needed.
+
+By using the Departments feature, you can ensure that tasks are assigned to the appropriate teams, enhancing the efficiency and productivity of your field service operations.

--- a/docs/user-guide/guide/field-service/forms.md
+++ b/docs/user-guide/guide/field-service/forms.md
@@ -1,94 +1,247 @@
 # Forms
 
-**Forms** are electronic documents that can be attached to tasks, allowing employees to submit task results directly through the **X-GPS Tracker** mobile app. These forms can include various types of fields such as text fields for client orders, inspection reports, and media sections for uploading photos and videos.
+**Forms** are electronic documents that can be attached to tasks, allowing employees to submit task results directly through the [X-GPS Tracker](../x-gps-mobile-apps/x-gps-tracker/) mobile app. These forms can include various types of fields such as text fields for client orders, inspection reports, and media sections for uploading photos and videos.
+
+<figure><img src="../../.gitbook/assets/image (9).png" alt="Forms page"><figcaption><p>Forms page</p></figcaption></figure>
 
 {% embed url="https://youtu.be/FaHJU_EEkUU" %}
 
-## Getting started
+## How to create a form
 
-### Create a form
+<figure><img src="../../.gitbook/assets/image-20240816-160834 (3).png" alt="Form creation dialogue"><figcaption><p>Creating a new form</p></figcaption></figure>
 
-To begin using forms in Navixy:
+To create a form in Navixy, follow the steps below. This process allows you to create as many forms as needed, ensuring they are tailored to the tasks your employees perform.
 
-1. Open the **Field service** module from the main menu.
-2. Click on the **Forms** tab to open the form management interface.
-3. Start the form creation process by clicking the **+** icon.
-4. Choose the necessary components (e.g., text fields, checkboxes, dropdowns, date, rating, image, file attachment, signature, and section separators) from the left side of the screen. Customize the form to suit your company's specific workflow and tasks.
+{% stepper %}
+{% step %}
+### Go to Forms
 
-This process allows you to create as many forms as needed, ensuring they are tailored to the tasks your employees perform.
+Open the **Field service** module from the main menu and select the **Forms** tab.
+{% endstep %}
 
-![](../../.gitbook/assets/image-20240816-160834.png)
+{% step %}
+### Start creating a form
+
+Click **+** to open the form creation dialogue.
+{% endstep %}
+
+{% step %}
+### Configure a form
+
+Choose the necessary components (e.g., text fields, checkboxes, dropdowns, date, rating, image, file attachment, signature, and section separators) from the left side of the screen. Customize the form to suit your company's specific workflow and tasks.
+{% endstep %}
+
+{% step %}
+### Save the form
+{% endstep %}
+{% endstepper %}
 
 Two toggles are available when creating a form:
 
-* **"Use by default when creating a task"**: If enabled, this form will automatically be attached to new tasks unless another form is selected. In the form list, this form will be marked with a “star” sign.
-* **"Submit form only in the zone"**: If enabled, the form can only be submitted when the employee is within a predefined geographic zone, ensuring that task reporting occurs at the correct location.
+* **Use by default when creating a task**: If enabled, this form will be attached to new tasks by default unless another form is selected. In the form list, this form will be marked with a star.
+* **Submit form only in the zone**: If enabled, the form can only be submitted when the employee is within a predefined geographic zone, ensuring that task reporting occurs at the correct location.
 
-After saving, created forms can be accessed in the form list.
+After saving, the created forms can be accessed through the form list.
 
-![List of created forms (example)](../../.gitbook/assets/image-20240816-155915.png)
+![List of created forms](<../../.gitbook/assets/image-20240816-155915 (3).png>)
 
-### Attaching a form to a task
+## How to attach a form to a task
+
+<figure><img src="../../.gitbook/assets/image (3).png" alt=""><figcaption></figcaption></figure>
 
 To attach a form to a task, follow these steps:
 
-1. Open the Task creation window: navigate to Tasks tab and click the "+" button to create a new task.
-2. Under the “Task form” field, choose the form you created earlier from the dropdown list.
-3. Provide other task details, such as selecting the employee responsible for completing the task.
-4. Finalize the task creation by clicking "Save."
+{% hint style="info" %}
+For detailed information about creating a task, see [How to create a task](tasks.md#how-to-create-a-task).
+{% endhint %}
 
-![](../../.gitbook/assets/image-20240816-161010.png)
+{% stepper %}
+{% step %}
+### Open the Task creation window
 
-The selected employee will receive the task with the attached form in the X-GPS Tracker mobile app, ensuring all necessary documentation is available during task execution.
+Navigate to **Tasks** tab and click **+** to open the task creation dialogue.
+{% endstep %}
 
-### Completing a form in X-GPS Tracker
+{% step %}
+### Select the employee responsible for completing the task
 
-Employees are required to fill out forms during or after completing a task. Here's how they can complete and submit a form:
+Select the driver who performs the task. You can add or configure drivers in **Fleet management → Drivers.**
+{% endstep %}
 
-1. Open X-GPS Tracker Mobile App on a mobile device.
-2. Switch to the "Tasks" section to view the list of assigned tasks.
-3. Select the task that needs to be completed.
-4. Click on the form within the task description and fill in all mandatory fields.
-5. Once all fields are filled, the form is automatically sent to the monitoring service, marking the task as completed.
+{% step %}
+### Select the task form
 
-### Configuring notifications for form submission
+&#x20;Choose the form you created earlier from the dropdown list at the bottom of the window.
+{% endstep %}
+
+{% step %}
+### Add task information
+
+Provide other task details.
+{% endstep %}
+
+{% step %}
+### Finalize task creation
+
+Click **Save** to finish creating the task. The selected employee will receive the task with the attached form in the X-GPS Tracker mobile app, ensuring all necessary documentation is available during task execution.
+{% endstep %}
+{% endstepper %}
+
+## How to submit a form in X-GPS Tracker
+
+Employees are required to fill out forms during or after completing a task. Follow these steps to complete and submit a form:
+
+{% stepper %}
+{% step %}
+### Open X-GPS Tracker
+
+Open the X-GPS Tracker app on your mobile device. If you don't have it set up, see [Invitation to X-GPS Tracker](../x-gps-mobile-apps/x-gps-tracker/invitation-to-x-gps-tracker.md) to learn how to receive access.
+{% endstep %}
+
+{% step %}
+### Switch to Tasks
+
+Switch to the **Tasks** screen to view the list of assigned tasks:\
+![](../../.gitbook/assets/Screenshot_20260403_140150.png)
+{% endstep %}
+
+{% step %}
+### Select the task to open it
+
+Tap the task to open its details:\
+![](../../.gitbook/assets/Screenshot_20260403_140202.png)
+{% endstep %}
+
+{% step %}
+### Open the form
+
+Tap the form attached to the task and fill in all mandatory fields:\
+![](../../.gitbook/assets/Screenshot_20260403_140803.png)
+{% endstep %}
+
+{% step %}
+### Submit the form
+
+Once all fields are filled, click **Submit** to send the form to the monitoring service. If your status is **Arrived**, the task status will automatically change to **Complete**.
+{% endstep %}
+{% endstepper %}
+
+## How to set up notifications for form submission
 
 To ensure timely notifications when a form is submitted, configure alerts by following these steps:
 
-1. Navigate to the [Rules and notifications](/broken/pages/af4DTfjY1sz82LLjmk4e) section in the platform.
-2. Start creating a new notification rule by clicking the "Add rule" button.
-3. Select the objects (e.g., vehicles, employees) to which this rule will apply.
-4. Choose [Task performance](../events-and-notifications/scheduling-and-dispatching/task-performance.md) from the list of events and proceed.
-5. In the “Rule options” section, tick the “Form submitted” checkbox.
-6. On the “Notifications” tab, choose how you want to be notified (e.g., SMS, email).
+{% stepper %}
+{% step %}
+### Go to Rules and alerts
+
+Navigate to the [Rules and alerts](../events-and-notifications/) module.
+{% endstep %}
+
+{% step %}
+### Go to **Alert rules**
+
+Click **Set rules** to open the **Alert rules** section.
+{% endstep %}
+
+{% step %}
+### Add a new rule
+
+Start creating a new notification rule by clicking **+**.
+{% endstep %}
+
+{% step %}
+### Select the objects
+
+Select the objects to which the rule will apply.
+{% endstep %}
+
+{% step %}
+### Select the rule type
+
+Choose [Task performance](../events-and-notifications/scheduling-and-dispatching/task-performance.md) in the **Type** drop-down menu. You can also give the rule a name.
+{% endstep %}
+
+{% step %}
+### Configure the rule
+
+Check the **Form submitted** checkbox in the second alert group. You can also enable the **Form resubmitted** option that appears if **Form submitted** is checked.
+{% endstep %}
+
+{% step %}
+### Configure notifications
+
+Enter notification text, notification type (emergency or push), and notification recipients by SMS or email.
+{% endstep %}
+{% endstepper %}
 
 These settings ensure you stay informed about task progress and form submissions in real time.
 
-### Viewing completed forms
+## How to view completed forms
 
-You can review and compare completed forms to assess employee performance and task outcomes:
+You can review and compare completed forms to assess employee performance and task outcomes by following these steps:
 
-1. Navigate to the “Field service” application.
-2. Click on the "Forms" tab to view all available forms.
-3. Hover over the form you wish to review and click “Submissions” on the right side.
-4. Choose the specific form submission from the list at the bottom.
+{% stepper %}
+{% step %}
+### Go to Forms
 
-**Submissions functionality:**
+Open the **Field service** module from the main menu and select the **Forms** tab.
+{% endstep %}
 
-* **Download forms:** Export the forms in Excel, CSV, or PDF formats.
-* **Filtering:** Use filters to narrow down submissions based on parameters like task creation date or employee name.
-* **Table customization:** Add or hide columns and form fields to focus on the most relevant data.
+{% step %}
+### Select the form
 
-### Task form data report
+Select the form you wish to review and click **Submissions** on the right side or the **Submissions** button on the toolbar.
 
-The “Task form data” report provides insights into employee performance based on completed forms. To generate this report:
+<figure><img src="../../.gitbook/assets/image (5).png" alt=""><figcaption></figcaption></figure>
+{% endstep %}
 
-1. Go to the [Reports](../reports/) section.
-2. Click on the “Create report” button.
-3. Choose the “Task form data” option.
-4. Tick the relevant objects (e.g., employees, tasks) for which you need the report.
-5. Specify the timeframe for the report.
-6. Click the “Build report” button to generate the report.
+{% step %}
+### View the submission page
 
-**Report details:**\
-The report shows form statistics, including the frequency and types of components selected. This data helps you evaluate employee performance and task outcomes more effectively.
+<figure><img src="../../.gitbook/assets/image (6).png" alt=""><figcaption></figcaption></figure>
+
+The submission page allows you to review and download the submitted form or forms.&#x20;
+
+To download the selected form in XLSX or PDF, click <img src="../../.gitbook/assets/image (7).png" alt="" data-size="line"> next to the form name. <img src="../../.gitbook/assets/image (8).png" alt="" data-size="line"> locks and unlocks form editing.
+
+If multiple forms have been submitted, you can download the form list in XLSX, CSV, or PDF format. The forms table supports filtering submissions based on parameters like task creation date or employee name and customization by adding or hiding columns and form fields to focus on the most relevant data.
+{% endstep %}
+{% endstepper %}
+
+## How to create task form values report
+
+The task form values report provides insights into employee performance based on completed forms.  It shows form statistics, including the frequency and types of components selected. This data helps you evaluate employee performance and task outcomes more effectively.
+
+To generate this report, follow these steps:
+
+{% stepper %}
+{% step %}
+### Go to Reports
+
+Navigate to the [Reports](../reports/) module.
+{% endstep %}
+
+{% step %}
+### Start creating the report
+
+Click **Create report** to open the report generation dialogue.
+{% endstep %}
+
+{% step %}
+### Choose the report type
+
+Select **Task form values**.
+{% endstep %}
+
+{% step %}
+### Configure the report
+
+Check the objects for which you need the report and select the timeframe. You can also choose to hide empty tabs and show unselected options.
+{% endstep %}
+
+{% step %}
+### Finish creating the report
+
+Click **Build report** to generate the report. After it's ready, it will appear on the reports list.<br>
+{% endstep %}
+{% endstepper %}

--- a/docs/user-guide/guide/field-service/places-field-service.md
+++ b/docs/user-guide/guide/field-service/places-field-service.md
@@ -1,24 +1,43 @@
 # Places
 
-**Places** in the **Field service** application can be used for organizing and managing key locations that your field staff need to visit, such as customer addresses, company sites, or other important points of interest. This helps streamline task assignments, optimize routes, and ensure efficient field operations.
+**Places (or POIs)** in the **Field service** module can be used for organizing and managing key locations that your field staff need to visit, such as customer addresses, company sites, or other important points of interest. This helps streamline task assignments, optimize routes, and ensure efficient field operations.
 
-![](../../.gitbook/assets/image-20240816-175137.png)
+The page contains the list of all available Places along with their details, including custom fields you've added.
 
-Upon entering the Places section, you will see a list of all available places along with their details, including custom fields you've added.
+<figure><img src="../../.gitbook/assets/image-20240816-174653 (3).png" alt="Places page"><figcaption><p>Places page</p></figcaption></figure>
 
-![](../../.gitbook/assets/image-20240816-174653.png)
+## How to create a Place
 
-## Creating and Managing Places
+{% stepper %}
+{% step %}
+### Go to Places
 
-When you create a new Place in Navixy's Field Service application, you can enter all the necessary information to make it easy to identify and manage. Start by giving the Place a name, specifying its address or selecting its location on the map. You can also add details like a description, tags, and any instructions relevant to the site.
+Open the **Places** page in the **Field service** module.
+{% endstep %}
 
-### Custom Fields
+{% step %}
+### Start creating a Place
 
-Custom fields let you add extra details that aren't covered by the standard options. These fields are tailored to your business needs, ensuring you have all the important information at your fingertips. For example:
+Click **+** to open the place creation dialogue.
+{% endstep %}
 
-* **Equipment type**: Record what equipment is at the site, like "4G antenna" or "Power generator."
-* **Maintenance schedule**: Note how often the site needs maintenance, such as "Monthly" or "Quarterly."
-* **Access code**: Store any security codes or instructions needed to access the site.
-* **Manager contact**: Include the contact details of the person responsible for the location.
+{% step %}
+### Enter Place details
 
-Using custom fields ensures that all the necessary information is organized and easily accessible, making field operations more efficient.
+<figure><img src="../../.gitbook/assets/image-20240816-175137 (3).png" alt="Creating a Place" width="563"><figcaption><p>Creating a Place</p></figcaption></figure>
+
+Enter the Place's label, address, and radius. You can also add a description, tags, and a file.&#x20;
+{% endstep %}
+
+{% step %}
+### (Optional) Add custom fields
+
+Custom fields let you add extra details that aren't covered by the standard options. These fields are tailored to your business needs. They can include equipment type stored at the site, site maintenance schedule, security code, or manager contacts.
+
+To manage custom fields, save the place, then reopen it and click **Custom fields** to open the **Custom fields** page for Places. Learn how to configure them in the [Custom fields](../account/custom-fields.md) article.
+{% endstep %}
+{% endstepper %}
+
+## How to use Places
+
+Places are used as a map tool to help you track your objects in the **Tracking** module. To learn more about their use for monitoring the map, see [Places (POIs)](../tracking/map-tools/places-pois.md). The **Tracking** module also allows [importing them](../tracking/map-tools/places-pois.md#importing-places-from-an-excel-file).

--- a/docs/user-guide/guide/field-service/staff.md
+++ b/docs/user-guide/guide/field-service/staff.md
@@ -1,14 +1,14 @@
 # Staff
 
-The **Staff** section in the **Field service** application is specifically designed to manage and organize information about your field staff effectively. This tool ensures that you have everything you need to coordinate your mobile workforce efficiently.
+The **Staff** page in the **Field service** module is designed to manage and organize information about your field staff. This tool ensures that you have everything you need to efficiently coordinate your mobile workforce.
 
-![](../../.gitbook/assets/image-20240816-171918.png)
+<figure><img src="../../.gitbook/assets/image-20240816-171918 (3).png" alt="Staff page"><figcaption><p>Staff page</p></figcaption></figure>
 
-To access the Staff section, log in to the Navixy platform and select "Field service" from the main menu. From there, click on the "Staff" tab. This section provides an overview of all employees in your organization, displaying their essential information in a list format.
+To access the **Staff** page, log in to the Navixy platform and click **Field service** in the main menu. From there, click the **Staff** tab. This section provides an overview of all employees in your organization, displaying their essential information in a list format.
 
-## List of employees
+## Employee list
 
-The employee list is designed for fast and convenient management of your workforce. It is especially useful in conjunction with the [Tasks](tasks.md) application, where you can easily assign tasks, communicate with employees, and monitor their progress.
+The employee list is designed for fast and convenient management of your workforce. It is especially useful in conjunction with the [Tasks](tasks.md) page, where you can easily assign tasks, communicate with employees, and monitor their progress.
 
 Each employee's information includes the following details:
 
@@ -21,30 +21,83 @@ Each employee's information includes the following details:
 
 The list view can be customized by adding or removing columns to display the most relevant information, such as driver license details, employee ID, hardware key, and more.
 
-### Adding a new employee
+## How to add a new employee
 
 To add a new employee to the system, follow these steps:
 
-1. **Click the Add Button:** Located at the top left corner of the "Staff" section.
-2. **Fill in Employee Details:** Enter the employee's name, contact information, location, and any other relevant details.
-3. **Assign to a Department:** Select the appropriate department or branch from the dropdown menu.
-4. **Save the Information:** Once all the details are entered, click "Save" to create the employee record.
+{% stepper %}
+{% step %}
+### Go to Staff
 
-### Importing employees
+Go to the **Staff** page in the **Field Service** module.
+{% endstep %}
 
-To efficiently add multiple employees to your Field service application, follow these steps:
+{% step %}
+### Start employee creation
 
-1. **Open the Staff section**: Go to the “Staff” section in the Field Service application.
-2. **Start the Import Process**: Click the “+” button and select “XLS” from the dropdown.
-3. **Upload the Excel file**: Download the example file and input the information you need. Once done, click “Browse” to select your Excel file (XLS, XLSX, or CSV). Ensure the “Use file headers box” is checked if your file includes headers.
-4. **Review and Continue**: Verify required fields like “First Name” and additional fields. Click “Continue” to complete the import.
+Click **+** to open the employee creation dialogue.
+{% endstep %}
 
-This process quickly adds employees to your directory, saving time and ensuring accuracy.
+{% step %}
+### Fill in employee details
 
-## Managing employee records
+Enter the employee's name, contact information, location, and any other relevant details.
+{% endstep %}
 
-Once employees are added to the system, you can easily manage and update their information as needed. The Staff section provides a summary view of each employee's details, with options to:
+{% step %}
+### Assign employee to department
+
+Select the appropriate department or branch from the dropdown menu.
+{% endstep %}
+
+{% step %}
+### Save
+
+Once all the details have been entered, click **Save** to create the employee record.
+{% endstep %}
+{% endstepper %}
+
+## How to import employees
+
+To add multiple employees to your staff list, follow these steps:
+
+{% stepper %}
+{% step %}
+### Go to Staff
+
+Go to the **Staff** page in the **Field Service** module.
+{% endstep %}
+
+{% step %}
+### Start import
+
+Hover your cursor over **+** and select XLS.
+{% endstep %}
+
+{% step %}
+### Prepare employee list
+
+Download the template by clicking **Example file** and enter the required information.
+{% endstep %}
+
+{% step %}
+### Upload employee list
+
+Click **Browse** to select your Excel file (XLS, XLSX, or CSV). Ensure the **Use file headers** box is checked if your file includes headers.
+{% endstep %}
+
+{% step %}
+### Complete import
+
+Click **Continue** to finish the import process.
+{% endstep %}
+{% endstepper %}
+
+## How to manage employee records
+
+Once employees are added to the system, you can easily manage and update their information as needed. The **Staff** page provides a summary view of each employee's details, allowing you to:
 
 * **Edit employee information:** Update details such as contact information, department, or assigned tasks.
 * **View employee location:** See the real-time location of employees who are assigned to a specific object or vehicle.
 * **Customize employee list view:** Adjust the columns displayed in the list to show the most relevant information for your operations.
+* **Search and delete employees**.

--- a/docs/user-guide/guide/field-service/tasks.md
+++ b/docs/user-guide/guide/field-service/tasks.md
@@ -1,44 +1,94 @@
 # Tasks
 
-A **Task** in Navixy refers to a specific assignment or job that needs to be completed by an employee or field worker. It includes detailed instructions about what needs to be done, where it should be done, and within what timeframe. Tasks can range from simple, one-off assignments like delivering a package to a single location, to more complex operations like visiting multiple checkpoints along a route to perform inspections, installations, or other services.
+A **Task** in Navixy refers to a specific assignment or job that needs to be completed by an employee or field worker. It includes detailed instructions about what needs to be done, where it should be done, and within what timeframe. Tasks can range from simple one-off assignments, such as delivering a package to a single location, to more complex operations, like visiting multiple checkpoints along a route to perform inspections, installations, or other services.
 
-![](../../.gitbook/assets/image-20240815-215838.png)
+Tasks are essential for managing and coordinating field operations, ensuring that employees are clear about their responsibilities, and allowing managers to monitor progress, optimize routes, and ensure that all jobs are completed efficiently. In the field, employees can view their task using the [X-GPS ](../x-gps-mobile-apps/x-gps-tracker/task-assignment.md)Tracker app.
 
-Tasks are essential for managing and coordinating field operations, ensuring that employees are clear about their responsibilities, and allowing managers to monitor progress, optimize routes, and ensure that all jobs are completed efficiently.
+<figure><img src="../../.gitbook/assets/image (1).png" alt="Tasks list"><figcaption><p>Tasks page</p></figcaption></figure>
 
 ## How to create a task
 
-1. Navigate to **Tasks** tab in **Field service** module
-2. Click the **“+”** button to begin the process of creating a new task.
-3. **Define the task name:**\
-   Enter a descriptive task name that helps identify the purpose of the task. This could be the name of the customer or a brief description of the task, such as "Install Equipment" or "Inspect Communications."
-4. **Specify the task address:**\
-   Enter the task address manually, select a point on the map, or use geographic coordinates. This will define the primary location for a single task or the first checkpoint for a route task.
-5. **Set the task time:**\
-   Define the date and time range during which the employee should complete the task. This ensures that the task is completed within the designated timeframe.
-6. **Add Checkpoints for Route tasks:**\
-   To create a route task, click “Add New Checkpoint” after setting the initial location. Each checkpoint represents an additional stop along the route, and they will be automatically connected in sequence. The employee must complete these checkpoints in the specified order.
-7. **Assign the task to an Employee:**\
-   Select the employee who will be responsible for the task. If necessary, you can assign the task later using the task list or utilize additional tools provided in the interface to make the assignment easier.
-8. **Additional task details:**
-   1. **Task description:** Provide any additional details that might be useful to the employee, such as contact information or special instructions.
-   2. **Form:** Select the form that the employee needs to complete while performing the task. Forms can be filled out directly in the X-GPS Tracker app.
-   3. **Tags:** Add relevant tags to the task to facilitate easy searching and categorization later.
-   4. **Order ID:** Assign an order ID that the client can use to track the status of the task via the “Courier on the Map” feature.
-9. Click **“Save”** to finalize and send the task to the employee’s mobile device.
+To create a task in Navixy, follow these steps:
 
-### Single and Route tasks
+{% hint style="info" %}
+The only required fields are task name and address.
+{% endhint %}
 
-* **Single tasks:** These are straightforward tasks where the employee visits a single location to perform the assigned duties. The task is completed once the employee has arrived at the specified address and performed the required actions.
-* **Route tasks:** These involve multiple checkpoints that the employee must visit in a specific order. This type of task is ideal for situations where the employee needs to visit several locations along a planned route, such as deliveries or inspections.
+{% stepper %}
+{% step %}
+### Go to Tasks
 
-The interface is designed to be intuitive, allowing managers and dispatchers to quickly create and manage both single and route tasks with ease, ensuring that all field operations are handled efficiently and effectively.
+Navigate to the **Tasks** tab in the **Field service** module.
+{% endstep %}
 
-### Route optimization feature
+{% step %}
+### Start creating a task
 
-Navixy’s **Route Optimization** feature helps couriers deliver packages efficiently by determining the best sequence for visiting multiple addresses across a city. It considers the location of each address, specific delivery time windows, and the starting point of the task to create the most optimal route.
+Click **+** to open the task creation dialogue.
 
-#### Key benefits:
+![](<../../.gitbook/assets/image-20240815-215838 (3).png>)
+{% endstep %}
+
+{% step %}
+### Enter task name
+
+Enter a descriptive task name that helps identify the purpose of the task. This could be the name of the customer or a brief description of the task, such as "Install Equipment" or "Inspect Communications."
+{% endstep %}
+
+{% step %}
+### Set task address
+
+Manually enter the task address, select a point on the map, or use geographic coordinates. This will define the primary location for a single task or the first checkpoint for a route task.
+{% endstep %}
+
+{% step %}
+### Add checkpoints for route tasks
+
+To create a route task (a task that consists of multiple subtasks), click **Add new checkpoint**. Each checkpoint represents an additional stop along the route, and they will be automatically connected in sequence. The employee must complete these checkpoints in the set order.
+{% endstep %}
+
+{% step %}
+### Set task date and time
+
+Click **Task date** to open the **Execution period** window and define the date and time range during which the employee should complete the task. You can also configure additional options, such as admissible delay, visit duration, and ignore random visits with a set duration.
+{% endstep %}
+
+{% step %}
+### Select the employee responsible for completing the task
+
+Select the driver who performs the task. You can add or configure drivers in **Fleet management → Drivers.**
+{% endstep %}
+
+{% step %}
+### Add task information
+
+Provide other task details, including:
+
+* **Task description:** Add any additional details that might be useful to the employee, such as contact information or special instructions.
+* **Radius:** Defines the permissible deviation from the specified location. If the employee or vehicle arrives within this radius, their status will be set to **Arrived**, allowing them to complete the task.
+* **Form:** Select the form that the employee needs to submit to complete the task. Forms can be filled out directly in the [X-GPS Tracker](../x-gps-mobile-apps/x-gps-tracker/) app.
+* **Tags:** Add relevant tags to the task to facilitate easy searching and categorization later.
+* **Order ID:** Assign an order ID that the client can use to track the status of the task via the **Courier on the map** feature.
+{% endstep %}
+
+{% step %}
+### Finalize task creation
+
+Click **Save** to finish creating the task. The selected employee will receive the task with the attached form in the X-GPS Tracker mobile app, ensuring all necessary documentation is available during task execution.
+{% endstep %}
+{% endstepper %}
+
+## Single and route tasks
+
+**Single tasks** are straightforward tasks where the employee visits a single location to perform the assigned duties. The task is completed once the employee has arrived at the specified address (status: **Arrived**) and performed the required actions, such as submitting the attached [form](forms.md).
+
+**Route tasks** involve multiple checkpoints that the employee must visit in a specific order. This type of task is ideal for situations where the employee needs to visit several locations along a planned route, such as deliveries or inspections.
+
+## Optimize route
+
+**Optimize route** is a feature that helps couriers deliver packages efficiently by determining the best sequence for visiting multiple addresses across a city. It considers the location of each address, specific delivery time windows, and the starting point of the task to create the most optimal route. To use it, click **Optimize route** at the bottom of the left panel of a configured route task. You'll be prompted to enter the start address and time.
+
+**Key benefits:**
 
 * **Fuel savings:** Minimizes travel distance, reducing fuel consumption.
 * **Faster deliveries:** Optimizes the sequence for quicker task completion.
@@ -46,50 +96,188 @@ Navixy’s **Route Optimization** feature helps couriers deliver packages effici
 
 The platform can optimize up to 25 points in a single route task, ensuring all deliveries are made on time and in the most efficient order.
 
-## Tasks import
+## How to import tasks
 
 When managing a large workforce or numerous tasks, importing tasks from an Excel file is more efficient than manually creating and assigning them one by one. This is particularly useful when tasks are generated by external systems such as CRMs.
 
-![](../../.gitbook/assets/image-20240815-220011.png)
+![](<../../.gitbook/assets/image-20240815-220011 (3).png>)
 
-### Import from Excel file
+## How to import tasks from an Excel file
 
-While developers can use an API for task import, there’s a simpler method available—importing tasks from an Excel file. Data should be presented in XLS, XLSX, or CSV spreadsheet formats.
+While developers can import tasks using [Navixy API](https://app.gitbook.com/o/YVLWhgAwCZPoU5vlRsCs/s/6dtcPLayxXVB2qaaiuIL/), there’s a simpler method: importing tasks from an Excel file. Follow these steps to import your tasks to the Navixy platform:
 
-#### How to import tasks from an Excel file
+{% stepper %}
+{% step %}
+### Start the import process
 
-1. **Start the import process:**
-   1. Hover your mouse over the “+” button in the tasks section.
-   2. Click on the **XLS** option.
-2. **Tasks import window:**
-   1. In the "Tasks import" window, you can download a **File example** template.
-   2. Set task parameters as needed.
-3. **Required fields:**\
-   Fields marked as "Required" must be filled in for the import to succeed. The system will reject the import if any required fields are missing.
-4. **Address vs. Coordinates:**\
-   You can specify an address instead of coordinates; the system will automatically determine the location.
+Hover your mouse over the **+** button in the tasks section and click **XLS**.
+{% endstep %}
 
-#### Import settings
+{% step %}
+### Prepare the file
 
-In addition to individual task settings, you can configure the following global settings:
+In the **Tasks import** window, click **File example** template to download a template. Adjust your files to match it.
+{% endstep %}
 
-* **Default Radius:** Defines the permissible deviation from the specified location. If the employee (or vehicle) arrives within this radius, the task will be considered completed even if they don’t reach the exact location.
-* **Auto-Assign Tasks:**
-  * **Ignore Address:** Tasks are evenly assigned to all employees.
-  * **Use Employee Address:** Tasks are assigned based on proximity to the employee's home address.
-  * **Use Department Address:** Tasks are assigned according to the distance from the employee's department._Note:_ The addresses of departments and employees should be specified on their respective profile cards.
+{% step %}
+### Upload the file
 
-By using these settings, you can streamline the task assignment process, ensuring tasks are efficiently distributed and completed.
+The only required field is the file itself. Max size is 10 Mb. Allowed formats are XLS, XLSX, and CSV.
+{% endstep %}
 
-### Import from TXT file
+{% step %}
+### Configure import settings
 
-#### How to import Tasks from a TXT file
+You can configure the following settings for uploaded tasks:
 
-1. **Start the Import Process:**
-   1. Hover your mouse over the **“+”** button in the tasks section.
-   2. Click on the **TXT** option.
-2. **Tasks import window:**
-   1. You will see the “Tasks import” window, which contains a large field.
-   2. Paste the task list from your spreadsheet directly into this field using clipboard (copy-paste).
+* **Default radius:** Defines the permissible deviation from the specified location. If the employee or vehicle arrives within this radius, the task will be considered completed even if they don’t reach the exact location.
+* **Auto-assign tasks:**
+  * **Do not assign:** Tasks are assigned to all employees.
+  * **To employees:** Check the employees you want to be assigned the task or tasks.
+    * **Ignore address:** Tasks are assigned without regard for the employee's address.
+    * **Use employee address**: Tasks are assigned based on proximity to the employee's home address.
+    * **Use department address:** Tasks are assigned according to the distance from the employee's department.
+  * **To vehicles:**
+    * **Ignore address:** Tasks are assigned without regard for the vehicle's address.
+    * **Use garage address:** Tasks are assigned based on proximity to the garage.
 
-This process allows you to efficiently import multiple tasks at once, streamlining your task management workflow.
+{% hint style="info" %}
+The addresses of departments and employees should be specified on their respective profile cards.
+{% endhint %}
+{% endstep %}
+
+{% step %}
+### Finalize import
+
+Click **Next** to finish importing the task or tasks.
+{% endstep %}
+{% endstepper %}
+
+## How to import tasks from a TXT file
+
+{% stepper %}
+{% step %}
+### Start the import process
+
+Hover your mouse over the **+** button in the tasks section and click **TXT.**
+{% endstep %}
+
+{% step %}
+### Enter your tasks
+
+Paste your tasks directly from the spreadsheet into the large field on the left of the **Tasks import** window (the only required field). Pay attention to the column headers.
+{% endstep %}
+
+{% step %}
+### Configure import settings
+
+Just like with importing from an Excel file, you can set the following options:
+
+* **Default radius:** Defines the permissible deviation from the specified location. If the employee or vehicle arrives within this radius, the task will be considered completed even if they don’t reach the exact location.
+* **Auto-assign tasks:**
+  * **Do not assign:** Tasks are assigned to all employees.
+  * **To employees:** Check the employees you want to be assigned the task or tasks.
+    * **Ignore address:** Tasks are assigned without regard for the employee's address.
+    * **Use employee address**: Tasks are assigned based on proximity to the employee's home address.
+    * **Use department address:** Tasks are assigned according to the distance from the employee's department.
+  * **To vehicles:**
+    * **Ignore address:** Tasks are assigned without regard for the vehicle's address.
+    * **Use garage address:** Tasks are assigned based on proximity to the garage.
+
+{% hint style="info" %}
+The addresses of departments and employees should be specified on their respective profile cards.
+{% endhint %}
+{% endstep %}
+
+{% step %}
+### Finalize import
+
+Click **Next** to finish importing the task or tasks.
+{% endstep %}
+{% endstepper %}
+
+## Recurring tasks
+
+Recurring tasks are tasks that are automatically repeated in set intervals. They are displayed on the **Recurring tasks** page of the **Field service** module.
+
+<figure><img src="../../.gitbook/assets/{B12DF7B4-4E70-4566-96CB-EAFF88061175}.png" alt=""><figcaption></figcaption></figure>
+
+## How to create a recurring task
+
+To create a recurring task, follow these steps:
+
+{% hint style="danger" %}
+At the moment, recurring tasks aren't supported by [X-GPS Tracker](../x-gps-mobile-apps/x-gps-tracker/).
+{% endhint %}
+
+{% stepper %}
+{% step %}
+### Go to Recurring tasks
+
+Navigate to the **Recurring tasks** tab in the **Field service** module.
+{% endstep %}
+
+{% step %}
+### Start creating a recurring task
+
+Click **+** to open the task creation dialogue.
+
+<figure><img src="../../.gitbook/assets/image (41).png" alt=""><figcaption></figcaption></figure>
+{% endstep %}
+
+{% step %}
+### Enter task name
+
+Enter a descriptive task name that helps identify the purpose of the task. This could be the name of the customer or a brief description of the task, such as "Install Equipment" or "Inspect Communications."
+{% endstep %}
+
+{% step %}
+### Set task address
+
+Manually enter the task address, select a point on the map, or use geographic coordinates. This will define the primary location for a single task or the first checkpoint for a route task.
+{% endstep %}
+
+{% step %}
+### Configure repeat frequency
+
+Click the **Repeat** block to open the recurrence settings and choose a preset or manually configure the dates when the task will be performed.
+{% endstep %}
+
+{% step %}
+### Add checkpoints for route tasks
+
+To create a route task (a task that consists of multiple subtasks), click **Add new checkpoint**. Each checkpoint represents an additional stop along the route, and they will be automatically connected in sequence. The employee must complete these checkpoints in the set order.
+{% endstep %}
+
+{% step %}
+### Set task time and duration
+
+Define the date and time range during which the employee should complete the task. This ensures that the task is completed within the designated timeframe.
+
+Click **Additionally** to display additional options, such as admissible delay, visit duration, and ignore random visits with a set duration.
+{% endstep %}
+
+{% step %}
+### Select the employee responsible for completing the task
+
+Select the driver who performs the task. You can add or configure drivers in **Fleet management → Drivers.**
+{% endstep %}
+
+{% step %}
+### Add task information
+
+Provide other task details, including:
+
+* **Description:** Add any additional details that might be useful to the employee, such as contact information or special instructions.
+* **Radius:** Defines the permissible deviation from the specified location. If the employee or vehicle arrives within this radius, their status will be set to **Arrived**, allowing them to complete the task.
+* **Form:** Select the form that the employee needs to submit to complete the task.
+* **Tags:** Add relevant tags to the task to facilitate easy searching and categorization later.
+* **Order ID:** Assign an order ID that the client can use to track the status of the task via the **Courier on the map** feature.
+{% endstep %}
+
+{% step %}
+### Finalize task creation
+
+Click **Save** to finish creating the task.
+{% endstep %}
+{% endstepper %}


### PR DESCRIPTION
## Summary

- Restores 5 Field service pages to their rewritten state from commit `50bc9b7` (GITBOOK-94, Apr 7 2026)
- Changes were lost when merge conflict in `801da60` resolved all 5 files by keeping `docs-restructure` versions, silently discarding Sofia's full content rewrite
- All 15 image assets referenced by the restored content already exist on the branch — no asset changes needed

## Files changed

- `docs/user-guide/guide/field-service/forms.md`
- `docs/user-guide/guide/field-service/tasks.md`
- `docs/user-guide/guide/field-service/staff.md`
- `docs/user-guide/guide/field-service/departments-field-service.md`
- `docs/user-guide/guide/field-service/places-field-service.md`

## What is restored

| File | Change |
|---|---|
| `forms.md` | ~94 → ~247 lines: steppers for create/attach/submit/notifications, figures, hints |
| `tasks.md` | ~144 → ~283 lines: steppers for create/import XLS/import TXT, figures, route docs |
| `staff.md` | Steppers for add/import employees, figure tag |
| `departments-field-service.md` | Stepper, new figure, link to Staff page |
| `places-field-service.md` | Stepper, figures, custom-fields step, Tracking module section |

## What is NOT changed

- `SUMMARY.md` (reflects valid later IoT Logic restructure)
- Any files outside `docs/user-guide/guide/field-service/`
- Image assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)